### PR TITLE
Add Svelte as a React alternative

### DIFF
--- a/items/react.md
+++ b/items/react.md
@@ -4,6 +4,8 @@ slug: 'react'
 alternatives:
   - title: 'Preact'
     link: 'https://preactjs.com/'
+  - title: 'Svelte'
+    link: 'https://svelte.technology'
   - title: 'Vue'
     link: 'https://vuejs.org/'
 ---


### PR DESCRIPTION
Add a link to Svelte in the list of React alternatives. Svelte is great because it compiles down to vanilla JS and doesn't require a runtime loaded into the browser.