### PR TITLE
Add JS++ and fix typo on TypeScript

### DIFF
--- a/items/flow.md
+++ b/items/flow.md
@@ -2,8 +2,10 @@
 title: 'Flow'
 slug: 'flow'
 alternatives:
-  - title: 'Typescript'
+  - title: 'TypeScript'
     link: 'https://www.typescriptlang.org/'
+  - title: 'JS++'
+    link: 'https://www.onux.com/jspp/'
 ---
 
 Flow adds static typing to JavaScript to improve developer productivity and code quality. Initially developed by Facebook.


### PR DESCRIPTION
JS++ is a seemingly inspired by C# language which is unfortunately rather unknown, but definitively an alternative to Flow. However, it is different from TypeScript and Flow as it does not support incremental compilation (yet?)

Also, "Typescript" might be right, but per unwritten convention, a scripting language's name including the word "script" has that word capitalized - or rather, camelcased. Hence: Type**S**cript.