### PR TITLE
Yarn

### DIFF
--- a/items/yarn.md
+++ b/items/yarn.md
@@ -1,0 +1,9 @@
+---
+title: 'Yarn'
+slug: 'yarn'
+alternatives:
+  - title: 'npm'
+    link: 'https://www.npmjs.com/'
+---
+
+Dependency management for JavaScript. Initially developed by Facebook.


### PR DESCRIPTION
although yarn is not referenced on [https://opensource.facebook.com/](https://opensource.facebook.com/), It was originally developed by FB as detailed here: [https://code.fb.com/web/yarn-a-new-package-manager-for-javascript/](https://code.fb.com/web/yarn-a-new-package-manager-for-javascript/)